### PR TITLE
Add compatibility with `@sanity-typed`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ defineType({
 })
 ```
 
+If you use [`@sanity-typed`](https://github.com/saiichihashimoto/sanity-typed/tree/main/packages/types#sanity-typedtypes), import `countryStateListPluginTyped` instead to get the correct types in your documents:
+
+```js
+import {countryStateListPluginTyped} from 'sanity-plugin-country-state-select'
+
+export default defineConfig({
+  // ...
+  plugins: [countryStateListPluginTyped()],
+})
+```
+
 ## Options
 
 - `showStates` - Boolean; to render states dropdown

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "url": "git+https://github.com/syedMSohaib/sanity-country-state-select.git"
   },
   "dependencies": {
+    "@sanity-typed/types": "^6.1.2",
     "@sanity/incompatible-plugin": "^1.0.4"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
-import {definePlugin} from 'sanity'
+import {definePlugin, castFromTyped} from '@sanity-typed/types'
 import {schema} from './schemas'
 
 interface MyPluginConfig {
   /* nothing here yet */
 }
 
-export const countryStateListPlugin = definePlugin<MyPluginConfig | void>((config = {}) => {
+export const countryStateListPluginTyped = definePlugin((config: MyPluginConfig | void) => {
   // eslint-disable-next-line no-console
   console.log('hello from sanity-country-state-select')
   return {
@@ -15,3 +15,5 @@ export const countryStateListPlugin = definePlugin<MyPluginConfig | void>((confi
     },
   }
 })
+
+export const countryStateListPlugin = castFromTyped(countryStateListPluginTyped)

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,11 +1,11 @@
-import {defineType, ObjectDefinition} from 'sanity'
+import {defineType, ObjectDefinition} from '@sanity-typed/types'
 import {CountryListOption} from '../components/countrySelectList.type'
 import {CountrySelectList} from '../components/CountrySelectList'
 
 const countryType = 'countrieslist' as const
 
 export interface CountryListTypeDefinition
-  extends Omit<ObjectDefinition, 'type' | 'fields' | 'options'> {
+  extends Omit<ObjectDefinition<any, any>, 'type' | 'fields' | 'options'> {
   type: typeof countryType
   options?: CountryListOption
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1745,6 +1745,13 @@
     colors "~1.2.1"
     string-argv "~0.3.1"
 
+"@sanity-typed/types@^6.1.2":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@sanity-typed/types/-/types-6.1.2.tgz#001a6c1a60ef105d8b50b57a556b662f333ab56a"
+  integrity sha512-VexAiYi54v9c8kcwHCmgEARuuVR8eJecGw5LkcC6AdnKJqnzUZ4i5uzph4PQGt6asPJh9CV7muihmvPjp73mGQ==
+  dependencies:
+    type-fest "4.8.3"
+
 "@sanity/asset-utils@^1.2.5":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@sanity/asset-utils/-/asset-utils-1.3.0.tgz#6460cd993a2c24368a6308028f3bc57df91f131e"
@@ -7563,6 +7570,11 @@ type-check@^0.4.0, type-check@~0.4.0:
   integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
   dependencies:
     prelude-ls "^1.2.1"
+
+type-fest@4.8.3:
+  version "4.8.3"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.8.3.tgz#6db08d9f44d596cd953f83020c7c56310c368d1c"
+  integrity sha512-//BaTm14Q/gHBn09xlnKNqfI8t6bmdzx2DXYfPBNofN0WUybCEUDcbCWcTa0oF09lzLjZgPphXAsvRiMK0V6Bw==
 
 type-fest@^0.18.0:
   version "0.18.1"


### PR DESCRIPTION
[![Watch How to Type Your Sanity Document and Client](https://github.com/saiichihashimoto/sanity-typed/assets/2819256/886bd64a-00fb-473c-a60a-205a8a6767ad)](https://github.com/saiichihashimoto/sanity-typed/assets/2819256/13c28e6a-74a7-4b3c-8162-61fae921323b)

[`@sanity-typed`](https://github.com/saiichihashimoto/sanity-typed) enables typed output from sanity's groq clients!

When using untyped plugins (like this one), it'll provide an `unknown` for the plugin's values, which isn't ideal. Luckily if you use the typed `definePlugin` and `castFromTyped` methods, you can enable typed values _and_ continue to support your default users!

[Here is the guide](https://github.com/saiichihashimoto/sanity-typed/tree/main/packages/types#writing-typed-plugins) on the changes in this PR.