### PR TITLE
rename sanity-country-state-select to sanity-plugin-country-state-select

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# sanity-country-state-select
+# sanity-plugin-country-state-select
 
 > This is a **Sanity Studio v3** plugin.
 
@@ -23,7 +23,7 @@ npm i sanity-plugin-country-state-select
 Add it as a plugin in `sanity.config.ts` (or .js):
 
 ```js
-import {countryStateListPlugin} from 'sanity-country-state-select'
+import {countryStateListPlugin} from 'sanity-plugin-country-state-select'
 
 export default defineConfig({
   // ...

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,9 +7,9 @@ interface MyPluginConfig {
 
 export const countryStateListPlugin = definePlugin<MyPluginConfig | void>((config = {}) => {
   // eslint-disable-next-line no-console
-  console.log('hello from sanity-country-state-select')
+  console.log('hello from sanity-plugin-country-state-select')
   return {
-    name: 'sanity-country-state-select',
+    name: 'sanity-plugin-country-state-select',
     schema: {
       types: [schema],
     },


### PR DESCRIPTION
Even though the repository is named `sanity-country-state-select`, the published npm package is `sanity-plugin-country-state-select`.